### PR TITLE
Document that delete() methods must not throw NoSuchFileException

### DIFF
--- a/src/main/java/org/icatproject/ids/plugin/ArchiveStorageInterface.java
+++ b/src/main/java/org/icatproject/ids/plugin/ArchiveStorageInterface.java
@@ -29,6 +29,9 @@ public interface ArchiveStorageInterface {
 	/**
 	 * Remove the data file from the specified location.
 	 * 
+	 * Implementations must not throw an error if the data file does
+	 * not exist in the storage.
+	 * 
 	 * @param location
 	 *            where to store the file
 	 * 

--- a/src/main/java/org/icatproject/ids/plugin/ArchiveStorageInterface.java
+++ b/src/main/java/org/icatproject/ids/plugin/ArchiveStorageInterface.java
@@ -13,8 +13,8 @@ import java.util.Set;
 public interface ArchiveStorageInterface {
 
 	/**
-	 * Delete the specified data set. A non-dummy version is needed if
-	 * StorageUnit is DATASET.
+	 * Delete the specified data set.
+	 * 
 	 * Implementations must not throw an error if the data set does
 	 * not exist in the storage.
 	 * 
@@ -27,8 +27,7 @@ public interface ArchiveStorageInterface {
 	public void delete(DsInfo dsInfo) throws IOException;
 
 	/**
-	 * Remove the data file from the specified location. A non-dummy version is
-	 * needed if StorageUnit is DATAFILE.
+	 * Remove the data file from the specified location.
 	 * 
 	 * @param location
 	 *            where to store the file
@@ -39,8 +38,7 @@ public interface ArchiveStorageInterface {
 	public void delete(String location) throws IOException;
 
 	/**
-	 * Get the specified data set. A non-dummy version is needed if StorageUnit
-	 * is DATASET.
+	 * Get the specified data set.
 	 * 
 	 * @param dsInfo
 	 *            describes the data set
@@ -55,8 +53,7 @@ public interface ArchiveStorageInterface {
 	public void get(DsInfo dsInfo, Path path) throws IOException;
 
 	/**
-	 * Store the specified data set. A non-dummy version is needed if
-	 * StorageUnit is DATASET.
+	 * Store the specified data set.
 	 * 
 	 * @param dsInfo
 	 *            describes the data set
@@ -70,8 +67,7 @@ public interface ArchiveStorageInterface {
 	public void put(DsInfo dsInfo, InputStream inputStream) throws IOException;
 
 	/**
-	 * Store the data file at the specified location. A non-dummy version is
-	 * needed if StorageUnit is DATAFILE.
+	 * Store the data file at the specified location.
 	 * 
 	 * @param inputStream
 	 *            stream of data to store
@@ -86,8 +82,7 @@ public interface ArchiveStorageInterface {
 	/**
 	 * Restore the datafiles from archive to main storage. Note that this is not
 	 * expected to throw any exceptions but will return a set of failed DfInfo
-	 * objects. A non-dummy version is needed if StorageUnit is DATAFILE. The
-	 * implementation is expected to make use of @see
+	 * objects. The  implementation is expected to make use of @see
 	 * {@link MainStorageInterface#put(InputStream,String location)} to store
 	 * the datafiles into main storage.
 	 * 

--- a/src/main/java/org/icatproject/ids/plugin/MainStorageInterface.java
+++ b/src/main/java/org/icatproject/ids/plugin/MainStorageInterface.java
@@ -14,6 +14,9 @@ public interface MainStorageInterface {
 	/**
 	 * Deletes the files of the specified data set.
 	 * 
+	 * Implementations must not throw an error if the data set does
+	 * not exist in the storage.
+	 * 
 	 * @param dsInfo
 	 *            describes the data set with the files to be deleted
 	 * 
@@ -24,6 +27,9 @@ public interface MainStorageInterface {
 
 	/**
 	 * Deletes the specified file
+	 * 
+	 * Implementations must not throw an error if the file does
+	 * not exist in the storage.
 	 * 
 	 * @param location
 	 *            location of the data file to be deleted

--- a/src/main/java/org/icatproject/ids/plugin/MainStorageInterface.java
+++ b/src/main/java/org/icatproject/ids/plugin/MainStorageInterface.java
@@ -14,9 +14,6 @@ public interface MainStorageInterface {
 	/**
 	 * Deletes the files of the specified data set.
 	 * 
-	 * A dummy implementation can be provided if no archive storage is
-	 * configured with storageUnit = DATASET
-	 * 
 	 * @param dsInfo
 	 *            describes the data set with the files to be deleted
 	 * 
@@ -27,9 +24,6 @@ public interface MainStorageInterface {
 
 	/**
 	 * Deletes the specified file
-	 * 
-	 * A dummy may be provided if the readOnly flag is set and no archive
-	 * storage has been configured with storageUnit = DATAFILE
 	 * 
 	 * @param location
 	 *            location of the data file to be deleted
@@ -52,9 +46,6 @@ public interface MainStorageInterface {
 	/**
 	 * See if the data set exists.
 	 * 
-	 * A dummy implementation can be provided if no archive storage is
-	 * configured with storageUnit set to dataset
-	 * 
 	 * @param dsInfo
 	 *            describes the data set being queried
 	 * 
@@ -64,9 +55,6 @@ public interface MainStorageInterface {
 
 	/**
 	 * See if the data file exists.
-	 * 
-	 * A dummy may be provided if the readOnly flag is set and no archive
-	 * storage has been configured with storageUnit = DATAFILE
 	 * 
 	 * @param location
 	 *            the value from datafile.location
@@ -102,9 +90,6 @@ public interface MainStorageInterface {
 	 * Return the list of DfInfos which should be archived to reduce the used
 	 * storage to between lowArchivingLevel and highArchivingLevel.
 	 * 
-	 * A dummy implementation can be provided if no archive storage is
-	 * configured with storageUnit set to datafile
-	 * 
 	 * The implementaion is free to do this however it chooses. Use might be
 	 * made of the information available from the java.nio.file.FileStore
 	 * (obtainable by Files.getFileStore(path) for any file to see whether or
@@ -128,9 +113,6 @@ public interface MainStorageInterface {
 	/**
 	 * Return the list of DsInfos which should be archived to reduce the used
 	 * storage to between lowArchivingLevel and highArchivingLevel.
-	 * 
-	 * A dummy implementation can be provided if no archive storage is
-	 * configured with storageUnit set to dataset
 	 * 
 	 * The implementaion is free to do this however it chooses. Use might be
 	 * made of the information available from the java.nio.file.FileStore
@@ -158,9 +140,6 @@ public interface MainStorageInterface {
 	 * This is only useful if the file system is available to the user. In this
 	 * case all files on the file system should only be readable by the user
 	 * running the ids server.
-	 * 
-	 * If the file system is not available to the user a dummy implementation
-	 * may be provided.
 	 * 
 	 * @param location
 	 *            the value from datafile.location
@@ -206,8 +185,6 @@ public interface MainStorageInterface {
 
 	/**
 	 * Store the data file at the specified location.
-	 * 
-	 * If no archive storage is in use a dummy may be provided.
 	 * 
 	 * @param inputStream
 	 *            stream of data to store

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -17,6 +17,8 @@
 				<li>Drop IOException from the MainStorageInterface.exists() methods.
 				Dummy implementations throw IllegalStateException rather then
 				IOException.  (Issue #5)</li>
+				<li>Document that delete() methods must not throw
+				NoSuchFileException.  (PR #9)</li>
 			</ul>
 		</section>
 


### PR DESCRIPTION
Add a note to the documentation of all `delete()` methods that these methods must not throw an error if the data objects to be deleted do not exist in the first place. In other words, implementations must catch `NoSuchFileException`. This will make things easier for ids.server if it just needs to make sure that some object is removed from main storage or archive storage. A former PR #1 did this already for one delete method, but not for all.

At the same time, I take the opportunity to remove all indications on when a dummy implementation of a calls may be provided.  This information was only partly accurate.  Plugin authors refer to [Writing an IDS plugin instructions](https://repo.icatproject.org/site/ids/plugin/1.4.0/manual.html) instead, which is kept up-to-date.
