### PR TITLE
Raise Java version to build for to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.icatproject</groupId>
 	<artifactId>ids.plugin</artifactId>
-	<version>1.5.1-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>IDS Plugin</name>
 	<description>IDS Plugin Interface and Utilities</description>
 
@@ -72,10 +72,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.5.1</version>
+				<version>3.11.0</version>
 				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
+					<release>11</release>
 				</configuration>
 			</plugin>
 

--- a/src/site/xdoc/release-notes.xml
+++ b/src/site/xdoc/release-notes.xml
@@ -8,6 +8,12 @@
 
 	<body>
 
+		<section name="2.0.0">
+			<ul>
+				<li>Raise Java version to build for to Java 11.  (PR #10)</li>
+			</ul>
+		</section>
+
 		<section name="1.5.0">
 			<ul>
 				<li>Add a new call lock(DsInfo, boolean) to the


### PR DESCRIPTION
Raise the Java version to build for to Java 11.  The main goal is to be consistent with upcoming `ids.server` 2.0.0 and to get rid of Java 8 once and for all.